### PR TITLE
Add regex validation

### DIFF
--- a/PetGame.Core/Exception/InsecurePasswordException.cs
+++ b/PetGame.Core/Exception/InsecurePasswordException.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace PetGame.Core
+{
+    /// <summary>
+    ///     Exception that is thrown when a user's password is insecure.
+    ///     This will happen when it does not meet the minimum password requirements.
+    /// </summary>
+    public class InsecurePasswordException : Exception
+    {
+        public InsecurePasswordException() : base() { }
+        public InsecurePasswordException(string message) : base(message) { }
+    }
+}

--- a/PetGame.Core/Models/Pet.cs
+++ b/PetGame.Core/Models/Pet.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace PetGame.Models
@@ -11,16 +12,37 @@ namespace PetGame.Models
     public class Pet
     {
         /// <summary>
+        ///     Regular expression for valid pet names. All pet names must pass this validation.
+        ///     Allows for names up to 50 char long that can contain spaces,
+        ///     but must not start or end with whitespace.
+        /// </summary>
+        public const string NameRegex = @"^[^\s]([$@._/-?!0-9a-zA-Z ]){2,50}[^\s]$";
+
+        /// <summary>
         ///     Gets or sets the unique Id of this pet.
         /// </summary>
         public ulong PetId { get; set; }
 
-        //TODO: Make a regex rule for pet names and apply it to the setter of the Name property
-
         /// <summary>
         ///     Gets or sets the name of this pet.
         /// </summary>
-        public string Name { get; set; }
+        public string Name
+        {
+            get => _Name;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "A pet name cannot be null or whitespace.");
+                }
+                if (!Regex.IsMatch(value, NameRegex))
+                {
+                    throw new ArgumentException("A pet name must meet the requirements.", nameof(value));
+                }
+                _Name = value;
+            }
+        }
+        private string _Name;
 
         /// <summary>
         ///     Gets or sets the birthday (and time) of when this pet was created.

--- a/PetGame.Core/Models/Pet.cs
+++ b/PetGame.Core/Models/Pet.cs
@@ -16,7 +16,7 @@ namespace PetGame.Models
         ///     Allows for names up to 50 char long that can contain spaces,
         ///     but must not start or end with whitespace.
         /// </summary>
-        public const string NameRegex = @"^[^\s]([$@._/-?!0-9a-zA-Z ]){2,50}[^\s]$";
+        public const string NameRegex = @"^([$@._/-?!0-9a-zA-Z])([$@._/-?!0-9a-zA-Z ]){0,48}[$@._/-?!0-9a-zA-Z]$";
 
         /// <summary>
         ///     Gets or sets the unique Id of this pet.

--- a/PetGame.Core/Models/User.cs
+++ b/PetGame.Core/Models/User.cs
@@ -13,8 +13,9 @@ namespace PetGame.Models
     {
         /// <summary>
         ///     Regular expression for valid usernames. All usernames must pass this validation.
+        ///     Allows for names betwen [2, 50] chars (inclusive) with the supported characters.
         /// </summary>
-        public const string UsernameRegex = @"^([$@._/-?!0-9a-zA-Z]){2,50}$";
+        public const string UsernameRegex = @"^[^\s]([$@._/-?!0-9a-zA-Z]){2,50}[^\s]$";
 
         /// <summary>
         ///     A user's unique identifier.

--- a/PetGame.Core/Models/User.cs
+++ b/PetGame.Core/Models/User.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 
 namespace PetGame.Models
@@ -11,21 +12,38 @@ namespace PetGame.Models
     public class User
     {
         /// <summary>
+        ///     Regular expression for valid usernames. All usernames must pass this validation.
+        /// </summary>
+        public const string UsernameRegex = @"^([$@._/-?!0-9a-zA-Z]){2,50}$";
+
+        /// <summary>
         ///     A user's unique identifier.
         /// </summary>
         public ulong UserId { get; set; }
         // yes, I am being optimistic by making the UserId an unsigned long
             
-        //TODO: Define a Regex for checking validity of usernames.
-
         /// <summary>
         ///     A user's name.
         ///     This must not be null or whitespace, and must be less than 32 characters in length.
-        ///     It should match a-zA-Z0-9!?.
+        ///     It should match the regex defined by <see cref="UsernameRegex"/>
         /// </summary>
-        public string Username { get; set; }
-
-        //TODO: Define a regex for minimum (plaintext) password requirements.
+        public string Username
+        {
+            get => _Username;
+            set
+            {
+                if (string.IsNullOrWhiteSpace(value))
+                {
+                    throw new ArgumentNullException(nameof(value), "Usernames may not be null or whitespace.");
+                }
+                if (!Regex.IsMatch(value, UsernameRegex))
+                {
+                    throw new ArgumentException("The username must match the username requirements.", nameof(value));
+                }
+                _Username = value;
+            }
+        }
+        private string _Username;
 
         /// <summary>
         ///     Represents a user's hash value.

--- a/PetGame.Core/Models/User.cs
+++ b/PetGame.Core/Models/User.cs
@@ -15,7 +15,7 @@ namespace PetGame.Models
         ///     Regular expression for valid usernames. All usernames must pass this validation.
         ///     Allows for names betwen [2, 50] chars (inclusive) with the supported characters.
         /// </summary>
-        public const string UsernameRegex = @"^[^\s]([$@._/-?!0-9a-zA-Z]){2,50}[^\s]$";
+        public const string UsernameRegex = @"^([$@._/-?!0-9a-zA-Z]){2,50}$";
 
         /// <summary>
         ///     A user's unique identifier.

--- a/PetGame.Tests/CryptographyTests.cs
+++ b/PetGame.Tests/CryptographyTests.cs
@@ -1,3 +1,4 @@
+using PetGame.Core;
 using PetGame.Models;
 using PetGame.Util;
 using System;
@@ -11,12 +12,26 @@ namespace PetGame.Tests
     public class CryptographyTests
     {
         [Fact]
+        public void TestBadPasswords()
+        {
+            var user = new User() { UserId = 1337, Username = "hackerman" };
+
+            // check null or whitespace
+            Assert.Throws<ArgumentNullException>(() => { Cryptography.SetUserPassword(user, ""); });
+            Assert.Throws<ArgumentNullException>(() => { Cryptography.SetUserPassword(user, null); });
+            Assert.Throws<InsecurePasswordException>(() => { Cryptography.SetUserPassword(user, "  "); });
+            Assert.Throws<InsecurePasswordException>(() => { Cryptography.SetUserPassword(user, "\t"); });
+            // check insecure (short) passwords
+            Assert.Throws<InsecurePasswordException>(() => { Cryptography.SetUserPassword(user, "short"); });
+        }
+
+        [Fact]
         public void TestLogin()
         {
             var user = new User()
             {
                 UserId = 0,
-                Username = "Test Dude"
+                Username = "hackerman"
             };
             // set the user's password and hmac key
             Cryptography.SetUserPassword(user, "Password123");

--- a/PetGame.Tests/PetTests.cs
+++ b/PetGame.Tests/PetTests.cs
@@ -70,19 +70,23 @@ namespace PetGame.Tests
         [Theory]
         [InlineData(null)]
         [InlineData("")]
-        [InlineData("s p a c e s")]
-        // 50 char
-        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsj")]
         // 51 char
         [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsja")]
         public void TestInvalidPetNames(string name)
         {
-            Assert.ThrowsAny<ArgumentException>(() =>
+            var ex = Assert.ThrowsAny<Exception>(() =>
             {
                 _ = new Pet()
                 {
                     Name = name
                 };
+            });
+
+            // check that the exception is one of these types
+            Assert.Contains(ex.GetType(), new List<Type>()
+            {
+                typeof(ArgumentNullException),
+                typeof(ArgumentException)
             });
         }
 
@@ -91,6 +95,9 @@ namespace PetGame.Tests
         [InlineData("peeeet")]
         [InlineData("idk")]
         [InlineData("Fluffy Jr")]
+        [InlineData("s p a c e s")]
+        // 50 char
+        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsj")]
         public void TestValidPetNames(string name)
         {
             _ = new Pet()

--- a/PetGame.Tests/PetTests.cs
+++ b/PetGame.Tests/PetTests.cs
@@ -1,0 +1,102 @@
+﻿using PetGame.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace PetGame.Tests
+{
+    /// <summary>
+    ///     Tests for the <see cref="Pet"/> class
+    /// </summary>
+    public class PetTests
+    {
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(101)]
+        public void TestInvalidEndurance(int endurance)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var p = new Pet()
+                {
+                    Endurance = endurance
+                };
+            });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(99)]
+        [InlineData(100)]
+        public void TestValidEndurance(int endurance)
+        {
+            // should not throw exception
+            _ = new Pet()
+            {
+                Endurance = endurance
+            };
+        }
+
+        [Theory]
+        [InlineData(-1)]
+        [InlineData(101)]
+        public void TestInvalidStrength(int strength)
+        {
+            Assert.Throws<ArgumentOutOfRangeException>(() =>
+            {
+                var p = new Pet()
+                {
+                    Strength = strength
+                };
+            });
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(1)]
+        [InlineData(99)]
+        [InlineData(100)]
+        public void TestValidStrength(int strength)
+        {
+            // should not throw exception
+            _ = new Pet()
+            {
+                Strength = strength
+            };
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("s p a c e s")]
+        // 50 char
+        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsj")]
+        // 51 char
+        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsja")]
+        public void TestInvalidPetNames(string name)
+        {
+            Assert.ThrowsAny<ArgumentException>(() =>
+            {
+                _ = new Pet()
+                {
+                    Name = name
+                };
+            });
+        }
+
+        [Theory]
+        [InlineData("fluffy")]
+        [InlineData("peeeet")]
+        [InlineData("idk")]
+        [InlineData("Fluffy Jr")]
+        public void TestValidPetNames(string name)
+        {
+            _ = new Pet()
+            {
+                Name = name
+            };
+        }
+    }
+}

--- a/PetGame.Tests/UserTests.cs
+++ b/PetGame.Tests/UserTests.cs
@@ -35,8 +35,6 @@ namespace PetGame.Tests
         [InlineData("invalid   ")]
         [InlineData("<script>alert(1);</script>")]
         [InlineData("Bobby 'DROP TABLE [User];--")]
-        // 50 char
-        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsj")]
         // 51 char
         [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsja")]
         public void TestInvalidUsernames(string name)
@@ -60,6 +58,8 @@ namespace PetGame.Tests
         [InlineData("!!!!!")]
         [InlineData("!?")]
         [InlineData("1337")]
+        // 50 char
+        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsj")]
         public void TestValidUsernames(string name)
         {
             _ = new User()

--- a/PetGame.Tests/UserTests.cs
+++ b/PetGame.Tests/UserTests.cs
@@ -35,6 +35,10 @@ namespace PetGame.Tests
         [InlineData("invalid   ")]
         [InlineData("<script>alert(1);</script>")]
         [InlineData("Bobby 'DROP TABLE [User];--")]
+        // 50 char
+        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsj")]
+        // 51 char
+        [InlineData("ljkasdfljkafsdjklfjkdjklfadsjkladfsjkladfsjklafdsja")]
         public void TestInvalidUsernames(string name)
         {
             Assert.Throws<ArgumentException>(() =>

--- a/PetGame.Tests/UserTests.cs
+++ b/PetGame.Tests/UserTests.cs
@@ -29,6 +29,7 @@ namespace PetGame.Tests
 
         [Theory]
         [InlineData("a")]
+        [InlineData("‽")]
         [InlineData("s p a c e s")]
         [InlineData(" invalid")]
         [InlineData("invalid   ")]
@@ -43,6 +44,25 @@ namespace PetGame.Tests
                     Username = name
                 };
             });
+        }
+
+
+        [Theory]
+        [InlineData("chris")]
+        [InlineData("hackerman")]
+        [InlineData("hackerman!!!")]
+        [InlineData("aa")]
+        [InlineData("ORANG")]
+        [InlineData("aAaAaAaA")]
+        [InlineData("!!!!!")]
+        [InlineData("!?")]
+        [InlineData("1337")]
+        public void TestValidUsernames(string name)
+        {
+            _ = new User()
+            {
+                Username = name
+            };
         }
     }
 }

--- a/PetGame.Tests/UserTests.cs
+++ b/PetGame.Tests/UserTests.cs
@@ -1,0 +1,48 @@
+﻿using PetGame.Models;
+using System;
+using System.Collections.Generic;
+using System.Text;
+using Xunit;
+
+namespace PetGame.Tests
+{
+    /// <summary>
+    ///     Tests the behavior of the <see cref="User"/> class.
+    /// </summary>
+    public class UserTests
+    {
+        [Theory]
+        [InlineData("")]
+        [InlineData(null)]
+        [InlineData("  ")]
+        [InlineData("\t")]
+        public void TestNullOrWhitespaceUsernames(string name)
+        {
+            Assert.Throws<ArgumentNullException>(() =>
+            {
+                var user = new User()
+                {
+                    Username = name
+                };
+            });
+        }
+
+        [Theory]
+        [InlineData("a")]
+        [InlineData("s p a c e s")]
+        [InlineData(" invalid")]
+        [InlineData("invalid   ")]
+        [InlineData("<script>alert(1);</script>")]
+        [InlineData("Bobby 'DROP TABLE [User];--")]
+        public void TestInvalidUsernames(string name)
+        {
+            Assert.Throws<ArgumentException>(() =>
+            {
+                var user = new User()
+                {
+                    Username = name
+                };
+            });
+        }
+    }
+}

--- a/PetGame.Tests/UserTests.cs
+++ b/PetGame.Tests/UserTests.cs
@@ -50,7 +50,6 @@ namespace PetGame.Tests
             });
         }
 
-
         [Theory]
         [InlineData("chris")]
         [InlineData("hackerman")]


### PR DESCRIPTION
Fix #31 

Adds regex validation rules to the Username, Pet name, and the plaintext password on registration. Will throw exception when these rules are not met.

Adds tests for this functionality.