### PR TITLE
Fix #48 Add Phone Number column to User table

### DIFF
--- a/PetGame.Core/Models/User.cs
+++ b/PetGame.Core/Models/User.cs
@@ -66,5 +66,10 @@ namespace PetGame.Models
         ///     This byte array will be 256 bytes in length.
         /// </remarks>
         public byte[] HMACKey { get; set; }
+
+        /// <summary>
+        ///     Gets or sets the User's phone number. If this value is null, the user has chosen not to recieve SMS notifications.
+        /// </summary>
+        public string PhoneNumber { get; set; } = null;
     }
 }

--- a/PetGame.Core/Models/User.cs
+++ b/PetGame.Core/Models/User.cs
@@ -18,6 +18,13 @@ namespace PetGame.Models
         public const string UsernameRegex = @"^([$@._/-?!0-9a-zA-Z]){2,50}$";
 
         /// <summary>
+        ///     Regular expression for valid phone numbers. All phone numbers must pass this 
+        ///     validation, or be set to null. This same validation (equivalent) is a constraint in the database.
+        ///     Valid number example: +10001112222
+        /// </summary>
+        public const string PhoneNumberRegex = @"^\+1([0-9]){10}$";
+
+        /// <summary>
         ///     A user's unique identifier.
         /// </summary>
         public ulong UserId { get; set; }
@@ -70,6 +77,28 @@ namespace PetGame.Models
         /// <summary>
         ///     Gets or sets the User's phone number. If this value is null, the user has chosen not to recieve SMS notifications.
         /// </summary>
-        public string PhoneNumber { get; set; } = null;
+        public string PhoneNumber
+        {
+            get => _PhoneNumber;
+            set
+            {
+                if (value == null)
+                    _PhoneNumber = null;
+                else
+                {
+                    if (Regex.IsMatch(value, PhoneNumberRegex))
+                    {
+                        _PhoneNumber = value;
+                    }
+                    else
+                    {
+                        throw new ArgumentException(paramName: nameof(value), message:
+                            "The supplied phone number was not valid.");
+                    }
+                }
+            }
+        }
+        // backing field
+        private string _PhoneNumber = null;
     }
 }

--- a/PetGame.Tests/UserTests.cs
+++ b/PetGame.Tests/UserTests.cs
@@ -67,5 +67,57 @@ namespace PetGame.Tests
                 Username = name
             };
         }
+
+        [Theory]
+        // valid number
+        [InlineData("+11231231234", true)]
+        // null ok
+        [InlineData(null, true)]
+        // empty / whitespace not ok
+        [InlineData("", false)]
+        [InlineData("  ", false)]
+        [InlineData("1231231234", false)]
+        // missing one char
+        [InlineData("+1231231234", false)]
+        [InlineData("+10000000000", true)]
+        // no special symbols
+        // TODO: Consider having the API normalize phone numbers before hitting the DB.
+        [InlineData("+1000000-0000", false)]
+        [InlineData("+1(000)000-0000", false)]
+        [InlineData("+1 (000) 000-0000", false)]
+        [InlineData("+19999999999", true)]
+        // one char too long
+        [InlineData("+199999999991", false)]
+        // no trailing/leading spaces
+        [InlineData("+19999999999 ", false)]
+        [InlineData(" +19999999999 ", false)]
+        [InlineData(" +19999999999", false)]
+        public void TestValidPhoneNumbers(string phoneNumber, bool valid)
+        {
+            if (valid)
+            {
+                // create the user, should not throw exception
+                _ = new User()
+                {
+                    PhoneNumber = phoneNumber
+                };
+            }
+            else
+            {
+                var e = Assert.ThrowsAny<Exception>(() =>
+                {
+                    // create the user, should throw exception
+                    _ = new User()
+                    {
+                        PhoneNumber = phoneNumber
+                    };
+                });
+                Assert.Contains(e.GetType(), new List<Type>()
+                {
+                    typeof(ArgumentException)
+                    // can check for different types, but currently only this one.
+                });
+            }
+        }
     }
 }

--- a/PetGame.sln
+++ b/PetGame.sln
@@ -27,6 +27,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "SQL", "SQL", "{DAACEFFD-EAD
 		SQL\Insert_SampleData_All.sql = SQL\Insert_SampleData_All.sql
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Migrations", "Migrations", "{CBB52B42-9239-41FD-BC9C-7E50DC36718A}"
+	ProjectSection(SolutionItems) = preProject
+		SQL\Migrations\01_Alter_Table_User_PhoneNumber.sql = SQL\Migrations\01_Alter_Table_User_PhoneNumber.sql
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +56,7 @@ Global
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{DAACEFFD-EAD5-434C-BD93-3F52EAF42A55} = {EA421D73-09A6-4935-80B3-0F70945E9329}
+		{CBB52B42-9239-41FD-BC9C-7E50DC36718A} = {DAACEFFD-EAD5-434C-BD93-3F52EAF42A55}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {C7E7B090-53CD-4DB9-9654-87BAE753D9D3}

--- a/PetGame/Services/LoginService.cs
+++ b/PetGame/Services/LoginService.cs
@@ -219,7 +219,7 @@ namespace PetGame
             {
                 var cmd = sql.CreateCommand();
                 cmd.CommandText =
-@"SELECT TOP 1 UserId, Username, PasswordHash, HMACKey FROM [User] WHERE Username = @Username;";
+@"SELECT TOP 1 UserId, Username, PasswordHash, HMACKey, PhoneNumber FROM [User] WHERE Username = @Username;";
                 cmd.Parameters.AddWithValue("@Username", username);
                 using (var reader = cmd.ExecuteReader())
                 {
@@ -230,6 +230,7 @@ namespace PetGame
                         ret.Username = reader.GetString(1);
                         ret.PasswordHash = reader.GetSqlBytes(2).Value;
                         ret.HMACKey = reader.GetSqlBytes(3).Value;
+                        ret.PhoneNumber = reader.IsDBNull(4) ? null : reader.GetString(4);
                     }
 
                     reader.Close();
@@ -305,10 +306,11 @@ namespace PetGame
             using (var s = sqlManager.EstablishDataConnection)
             {
                 var cmd = s.CreateCommand();
-                cmd.CommandText = "INSERT INTO [User] (Username, PasswordHash, HMACKey) OUTPUT INSERTED.UserID VALUES (@Username, @PasswordHash, @HMACKey);";
+                cmd.CommandText = "INSERT INTO [User] (Username, PasswordHash, HMACKey, PhoneNumber) OUTPUT INSERTED.UserID VALUES (@Username, @PasswordHash, @HMACKey, NULL);";
                 cmd.Parameters.AddWithValue("@Username", u.Username);
                 cmd.Parameters.AddWithValue("@PasswordHash", u.PasswordHash);
                 cmd.Parameters.AddWithValue("@HMACKey", u.HMACKey);
+                // TODO: Add the PhoneNumber to the user registration form
 
                 using (var reader = cmd.ExecuteReader())
                 {

--- a/SQL/Migrations/01_Alter_Table_User_PhoneNumber.sql
+++ b/SQL/Migrations/01_Alter_Table_User_PhoneNumber.sql
@@ -1,0 +1,21 @@
+﻿/*
+Migration #01, run these in order
+
+Alters the User table to add the PhoneNumber column.
+This defaults to a NULL value.
+Numbers are stored as strings, in the format:
++1XXXYYYZZZZ
+where XXX = area code
+YYYZZZZ = phone number.
+
+We are assuming that all phone numbers are located in the US.
+This is the format that is accepted by the Twilio API, which is what is planned for SMS.
+*/
+
+ALTER TABLE [User] ADD
+	PhoneNumber char(12) NULL DEFAULT(NULL)
+	CONSTRAINT PhoneNumber_IsNumeric
+	CHECK (PhoneNumber IS NULL OR PhoneNumber LIKE '+1[0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9][0-9]');
+
+-- sample usage
+-- UPDATE [User] Set PhoneNumber = '+14255555555' WHERE Username LIKE 'chris%';


### PR DESCRIPTION
Fix #48 Add Phone Number column to User table

Adds the alteration script for adding the PhoneNumber column to the User table.
This is in the required format to be used by Twilio.
Updates the usages of User to populate this value from the DB.