### PR TITLE
Send confirmation notification + Discord webhook support

### DIFF
--- a/PetGame/Controllers/LoginController.cs
+++ b/PetGame/Controllers/LoginController.cs
@@ -11,6 +11,7 @@ using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using PetGame.Core;
 using PetGame.Models;
+using PetGame.Services;
 using PetGame.Util;
 
 // For more information on enabling Web API for empty projects, visit https://go.microsoft.com/fwlink/?LinkID=397860
@@ -21,10 +22,12 @@ namespace PetGame
     public class LoginController : Controller
     {
         private readonly SqlManager sqlManager;
+        private readonly TwilioService twilio;
 
-        public LoginController(SqlManager sqlManager) : base()
+        public LoginController(SqlManager sqlManager, TwilioService twilio) : base()
         {
             this.sqlManager = sqlManager;
+            this.twilio = twilio;
         }
         private void SignIn(UserToken ut)
         {
@@ -71,7 +74,7 @@ namespace PetGame
         public IActionResult PostRegister()
         {
             var svc = new LoginService(sqlManager);
-            var ut = svc.RegisterNewUser(this as ControllerBase);
+            var ut = svc.RegisterNewUser(this as ControllerBase, twilio);
             if (ut == null)
                 // bad data
                 return Unauthorized();

--- a/PetGame/Controllers/LoginController.cs
+++ b/PetGame/Controllers/LoginController.cs
@@ -22,9 +22,9 @@ namespace PetGame
     public class LoginController : Controller
     {
         private readonly SqlManager sqlManager;
-        private readonly TwilioService twilio;
+        private readonly NotificationService twilio;
 
-        public LoginController(SqlManager sqlManager, TwilioService twilio) : base()
+        public LoginController(SqlManager sqlManager, NotificationService twilio) : base()
         {
             this.sqlManager = sqlManager;
             this.twilio = twilio;

--- a/PetGame/Services/LoginService.cs
+++ b/PetGame/Services/LoginService.cs
@@ -332,7 +332,7 @@ namespace PetGame
         /// Registers a new user with the supplied credentials, and returns it's usertoken.
         /// </summary>
         /// <returns></returns>
-        public UserToken RegisterNewUser(ControllerBase controllerContext, TwilioService sms = null)
+        public UserToken RegisterNewUser(ControllerBase controllerContext, NotificationService sms = null)
         {
             // create LoginModel from the request
             UserLoginModel data = new UserLoginModel();
@@ -385,6 +385,9 @@ namespace PetGame
                         // handle all exceptions, we don't care if this errors out
                     }
                 }
+
+                // send the discord webhook 
+                sms.SendDiscordWebhookNotification($"New user registered: `{user.Username}`");
             }
 
             // return the user token for this user

--- a/PetGame/Services/LoginService.cs
+++ b/PetGame/Services/LoginService.cs
@@ -3,6 +3,7 @@ using Microsoft.AspNetCore.Mvc;
 using Newtonsoft.Json;
 using PetGame.Core;
 using PetGame.Models;
+using PetGame.Services;
 using PetGame.Util;
 using System;
 using System.Collections.Generic;
@@ -331,7 +332,7 @@ namespace PetGame
         /// Registers a new user with the supplied credentials, and returns it's usertoken.
         /// </summary>
         /// <returns></returns>
-        public UserToken RegisterNewUser(ControllerBase controllerContext)
+        public UserToken RegisterNewUser(ControllerBase controllerContext, TwilioService sms = null)
         {
             // create LoginModel from the request
             UserLoginModel data = new UserLoginModel();
@@ -368,6 +369,16 @@ namespace PetGame
 
             // register a new user
             var user = InsertNewUser(data.username, data.password, data.PhoneNumber);
+
+            // if sms svc supplied
+            if (sms != null)
+            {
+                // and user defined
+                if (user.PhoneNumber != null)
+                {
+                    sms.SendMessage(user.PhoneNumber, $"Thanks for registering, {user.Username}. Welcome to PGTRTKD3000DGOTY.");
+                }
+            }
 
             // return the user token for this user
             return MakeUserToken(controllerContext, user);

--- a/PetGame/Services/LoginService.cs
+++ b/PetGame/Services/LoginService.cs
@@ -376,7 +376,14 @@ namespace PetGame
                 // and user defined
                 if (user.PhoneNumber != null)
                 {
-                    sms.SendMessage(user.PhoneNumber, $"Thanks for registering, {user.Username}. Welcome to PGTRTKD3000DGOTY.");
+                    try
+                    {
+                        sms.SendMessage(user.PhoneNumber, $"Thanks for registering, {user.Username}. Welcome to PGTRTKD3000DGOTY.");
+                    }
+                    catch (Exception)
+                    {
+                        // handle all exceptions, we don't care if this errors out
+                    }
                 }
             }
 

--- a/PetGame/Services/TwilioService.cs
+++ b/PetGame/Services/TwilioService.cs
@@ -103,7 +103,15 @@ namespace PetGame.Services
             // init the client
             TwilioClient.Init(AccountSid, AuthToken);
             // create the message and send it
-            MessageResource.Create(to, from: FromPhone, body: message);
+            try
+            {
+                MessageResource.Create(to, from: FromPhone, body: message);
+            }
+            catch (Twilio.Exceptions.ApiException e)
+            {
+                // can be thrown if the phone number is not valid
+                // fail silently
+            }
         }
     }
 }

--- a/PetGame/Startup.cs
+++ b/PetGame/Startup.cs
@@ -26,7 +26,7 @@ namespace PetGame
             // connection string must be set in the environment variables to connect to a MSSQL db instance
             var connectionString = Environment.GetEnvironmentVariable("PETGAME_DB_CONNECTION_STRING");
             services.AddSingleton<SqlManager>(new SqlManager(connectionString));
-            services.AddSingleton(new TwilioService());
+            services.AddSingleton(new NotificationService());
             services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
                 .AddCookie(options =>
                 {

--- a/README.md
+++ b/README.md
@@ -30,5 +30,7 @@ In your `PetGame` project configuration, add the following environment variables
 | `PETGAME_TWILIO_PHONENUM` | `+1XXXYYYZZZZ` | Twilio phone number for sending messages. |
 | `PETGAME_TWILIO_DEBUGNUM` | `+1XXXYYYZZZZ` | Phone number for sending debug messages. |
 | `PETGAME_TWILIO_DEBUGONLY` | `True` or `False` | If True, **all** messages will only be sent to the debug phone number. |
+| `PETGAME_DISCORD_USEWEBHOOK` | `True` or `False` | If True, messages will be sent with the supplied webhook. |
+| `PETGAME_DISCORD_WEBHOOK` | `(secret)` | The webhook url to send messages to. |
 
 This will point the ASP.NET connections to your local database.


### PR DESCRIPTION
Sends a confirmation SMS to users, if they supplied their phone number.
Adds support for sending notifications via discord webhooks.

Fix #49 